### PR TITLE
Config. base de base de datos H2 para desarrollo

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=task-planner
+
+spring.datasource.url=jdbc:h2:mem:taskplanner_dev
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.jpa.show-sql=true


### PR DESCRIPTION
En application.properties se configuró la base de datos H2 para usar durante el desarrollo de la aplicación.

[AB#43](https://dev.azure.com/nalancay/222378bf-87b6-409f-85f4-878346e9c4c5/_workitems/edit/43)